### PR TITLE
Fixes a bug that causes an unhelpful NullReferenceException when running under Mono

### DIFF
--- a/src/NHibernate.ByteCode.Castle/LazyInitializer.cs
+++ b/src/NHibernate.ByteCode.Castle/LazyInitializer.cs
@@ -74,9 +74,17 @@ namespace NHibernate.ByteCode.Castle
 			}
 			catch (TargetInvocationException tie)
 			{
-				// Propagate the inner exception so that the proxy throws the same exception as
-				// the real object would 
-				Exception_InternalPreserveStackTrace.Invoke(tie.InnerException, new Object[] { });
+				/* Propagate the inner exception so that the proxy throws the same exception as
+				 * the real object would.
+				 *
+				 * Also, if the Exception_InternalPreserveStackTrace method does not exist (it's an undocumented feature of the
+				 * internal framework that could vanish at any time) then don't use it. We are likely to lose the stack trace
+				 * but at least we will preserve the underlying exception type (which I think is the lesser of two evils).
+				 */
+				if(Exception_InternalPreserveStackTrace != null)
+				{
+					Exception_InternalPreserveStackTrace.Invoke(tie.InnerException, new Object[] { });
+				}
 				throw tie.InnerException;
 			}
 		}


### PR DESCRIPTION
...o

If running this library under a Mono environment instead of .NET framework
and a TargetInvocationException is caught within
LazyInitializer.Intercept(IInvocation) then you will see a stack trace something
like:

System.NullReferenceException: Object reference not set to an instance of an object
  at NHibernate.ByteCode.Castle.LazyInitializer.Intercept(IInvocation invocation)

This is because it makes use of reflection to invoke the private/internal method
'InternalPreserveStackTrace' of the Exception type.  This is undocumented
functionality and not a part of the API.  This method does not exist within the
Mono framework.
- This commit simply null-checks that method and - if it does not exist - skips
  attempting to call it.  Whilst we may lose the stack trace as a result, we
  still preserve some of the original exception and avoid throwing a completely
  unhelpful exception.
